### PR TITLE
Fix error when building w/Ruby 3.2

### DIFF
--- a/scripts/build_libressl.rb
+++ b/scripts/build_libressl.rb
@@ -246,7 +246,7 @@ end
 
 $libs_libressl_dir = "#{$libs_dir}/LibreSSL"
 
-FileUtils.mkdir($libs_libressl_dir, :verbose=>true) if !Dir.exists?($libs_libressl_dir)
+FileUtils.mkdir($libs_libressl_dir, :verbose=>true) if !Dir.exist?($libs_libressl_dir)
 puts "Changing dir to \"#{$libs_libressl_dir}\"."
 Dir.chdir($libs_libressl_dir)
 

--- a/scripts/build_llvm.rb
+++ b/scripts/build_llvm.rb
@@ -123,14 +123,14 @@ def getLLVMSourceDownloadAndExtract()
 			cmake_src_folder # target dir
 		)
 		
-		FileUtils.rm_r("cmake") if Dir.exists?("cmake")
+		FileUtils.rm_r("cmake") if Dir.exist?("cmake")
 		FileUtils.mv(cmake_src_folder, "cmake", :verbose=>true)
 	end
 
 	# Get benchmark src, which seems to be required, even though we build without benchmark support.
-	if !(Dir.exists?("third-party") && Dir.exists?("third-party/benchmark"))
+	if !(Dir.exist?("third-party") && Dir.exist?("third-party/benchmark"))
 		
-		FileUtils.mkdir("third-party") if !Dir.exists?("third-party")
+		FileUtils.mkdir("third-party") if !Dir.exist?("third-party")
 
 		Dir.chdir("third-party") do 
 			print_and_exec_command("git clone https://github.com/google/benchmark.git")
@@ -250,7 +250,7 @@ $glare_core_libs_dir = $glare_core_libs_dir.gsub("\\", "/")
 
 $llvm_dir = "#{$glare_core_libs_dir}/llvm"
 
-FileUtils.mkdir($llvm_dir, :verbose=>true) if !Dir.exists?($llvm_dir)
+FileUtils.mkdir($llvm_dir, :verbose=>true) if !Dir.exist?($llvm_dir)
 puts "Chdir to \"#{$llvm_dir}\"."
 Dir.chdir($llvm_dir)
 

--- a/scripts/cmake.rb
+++ b/scripts/cmake.rb
@@ -65,7 +65,7 @@ class CMakeBuild
 		
 		# allow_reconfig controls if the cmake directory will be deleted or if it can be reconfigured.
 		if allow_reconfig == false
-			if File.exists?(@build_dir)
+			if File.exist?(@build_dir)
 				FileUtils.rm_r(@build_dir)
 				puts "#{@build_name} CMake configure: Deleted old build directory."
 			end
@@ -73,7 +73,7 @@ class CMakeBuild
 			FileUtils.mkdir(@build_dir)
 		end
 		
-		if File.exists?(@install_dir)
+		if File.exist?(@install_dir)
 			FileUtils.rm_r(@install_dir)
 			puts "#{@build_name} CMake configure: Deleted old install directory."
 		end
@@ -158,7 +158,7 @@ class CMakeBuild
 		success_file_path = "#{install_dir}/#{successFilename()}"
 
 		# File doesn't exist: build was unsuccessful.
-		if !File.exists?(success_file_path)
+		if !File.exist?(success_file_path)
 			return false
 		end
 

--- a/scripts/script_utils.rb
+++ b/scripts/script_utils.rb
@@ -223,7 +223,7 @@ end
 
 def downloadFileHTTPSIfNotOnDisk(disk_path, uri_string)
 
-	if File.exists?(disk_path)
+	if File.exist?(disk_path)
 		puts "Already present on disk at '#{disk_path}', skipping download of '#{uri_string}'."
 		return
 	end
@@ -259,7 +259,7 @@ def extractArchive(archive, silent = false)
 				exec_command("\"#{sevenz_path}\" x #{tar_archive} -y#{silent_flag}")
 				puts "Done."
 
-				if File.exists?(tar_archive)
+				if File.exist?(tar_archive)
 					FileUtils.rm_r(tar_archive)
 				end
 			elsif archive.include?(".zip")
@@ -291,8 +291,8 @@ def extractArchiveIfNotExtraced(archive, target_dir, silent = false)
 	
 	temp_extract_dir = "temp_#{target_dir}"
 	
-	FileUtils.rm_r(target_dir) if Dir.exists?(target_dir)
-	FileUtils.rm_r(temp_extract_dir) if Dir.exists?(temp_extract_dir)
+	FileUtils.rm_r(target_dir) if Dir.exist?(target_dir)
+	FileUtils.rm_r(temp_extract_dir) if Dir.exist?(temp_extract_dir)
 	
 	FileUtils.mkdir(temp_extract_dir)
 	
@@ -300,7 +300,7 @@ def extractArchiveIfNotExtraced(archive, target_dir, silent = false)
 		extractArchive("../" + archive, silent)
 	end
 	
-	if Dir.exists?(temp_extract_dir + "/" + target_dir)
+	if Dir.exist?(temp_extract_dir + "/" + target_dir)
 		FileUtils.touch("#{temp_extract_dir}/#{target_dir}/glare-extract.success")
 		FileUtils.mv(temp_extract_dir + "/" + target_dir, ".")
 		FileUtils.rm_r(temp_extract_dir)


### PR DESCRIPTION
Hi,
I found a bug in the four ruby scripts located in the scripts directory while trying to build substrata. Since Ruby 3.2, File.exists? and Dir.exists? have been changed to File.exist? and Dir.exist?.
When installing ruby on ubuntu, Ruby 3.2.3 is installed, which produces this issue.
Here is the documentation showing this method is depreciated: [https://ruby-doc.org/core-2.2.0/File.html#exist-3F-method](https://ruby-doc.org/core-2.2.0/File.html#exist-3F-method)
Thanks